### PR TITLE
Update UUID generation to use latest API

### DIFF
--- a/item.go
+++ b/item.go
@@ -105,7 +105,7 @@ func (i *Item) save() error {
 
 func (i *Item) create() error {
 	if i.UUID == "" {
-		i.UUID = uuid.NewV4().String()
+		i.UUID = uuid.Must(uuid.NewV4()).String()
 	}
 	i.CreatedAt = time.Now()
 	i.UpdatedAt = time.Now()
@@ -132,7 +132,7 @@ func (i *Item) delete() error {
 }
 
 func (i Item) copy() (Item, error) {
-	i.UUID = uuid.NewV4().String()
+	i.UUID = uuid.Must(uuid.NewV4()).String()
 	i.UpdatedAt = time.Now()
 	err := i.create()
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -117,7 +117,7 @@ func (u *User) create() error {
 		return fmt.Errorf("Unable to register")
 	}
 
-	u.UUID = uuid.NewV4().String()
+	u.UUID = uuid.Must(uuid.NewV4()).String()
 	u.Password = Hash(u.Password)
 	u.CreatedAt = time.Now()
 


### PR DESCRIPTION
Update the UUID string generation to use the latest satori/go.uuid API.

Note this was just blindly applied based on [comment here](https://github.com/satori/go.uuid/issues/66#issuecomment-375948956). I have very little Go experience, so apologies if I managed to mess up something in those 3 lines.