### PR TITLE
Add -foreground option to run in foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ and
 ```
 default port is `8888` and database file named `sf.db` will be created in working directory
 
+#### Run the server in foreground:
+
+```
+standardfile -foreground
+```
+
+This will not daemonise the service, which might be handy if you want to handle that on some other level, like with init system, inside docker container, etc. 
+
+To stop the service, kill the process or press `ctrl-C` if running in terminal.
+
 #### Migrations
 To perform migrations run `standardfile --migrate`
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ var (
 	port    = flag.Int("p", 8888, `port to listen on`)
 	dbpath  = flag.String("db", "sf.db", `db file location`)
 	debug   = flag.Bool("debug", false, `enable debug output`)
+	foreground   = flag.Bool("foreground", false, `run in foreground`)
 	run     = make(chan bool)
 )
 
@@ -25,6 +26,11 @@ func main() {
 
 	if *migrate {
 		Migrate(*dbpath)
+		return
+	}
+
+	if *foreground {
+		worker(*port, *dbpath)
 		return
 	}
 


### PR DESCRIPTION
This is adding `-foreground` option to run the server in foreground instead of daemonising it. This might come handy if you want to handle the daemonisation somewhere else. (using init system for example) 