### PR TITLE
pure.Decode now takes httpext.QueryParams. Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,13 @@ go 1.12
 require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/go-playground/ansi v2.1.0+incompatible // indirect
-	github.com/go-playground/form v3.1.4+incompatible // indirect
-	github.com/go-playground/pure v0.0.0-20170911042516-dd99f50b7780
+	github.com/go-playground/ansi v2.1.0+incompatible
+	github.com/go-playground/form v3.1.4+incompatible
+	github.com/go-playground/pkg v3.1.4+incompatible
+	github.com/go-playground/pure v5.0.2+incompatible
 	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
 	github.com/heetch/confita v0.5.1
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/pkg/errors v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,17 @@ github.com/go-playground/ansi v2.1.0+incompatible/go.mod h1:OCdnfTFO/GfFtp+ktUt+
 github.com/go-playground/form v3.1.3+incompatible/go.mod h1:lhcKXfTuhRtIZCIKUeJ0b5F207aeQCPbZU09ScKjwWg=
 github.com/go-playground/form v3.1.4+incompatible h1:lvKiHVxE2WvzDIoyMnWcjyiBxKt2+uFJyZcPYWsLnjI=
 github.com/go-playground/form v3.1.4+incompatible/go.mod h1:lhcKXfTuhRtIZCIKUeJ0b5F207aeQCPbZU09ScKjwWg=
+github.com/go-playground/pkg v0.0.0-20190513234448-af45a46936e9 h1:SMJgXE/ouCVX21NWAS6yfOmwPn8HvT1Ty4UAGWGr60w=
+github.com/go-playground/pkg v0.0.0-20190513234448-af45a46936e9/go.mod h1:Wg1j+HqWLhhVIfYdaoOuBzdutBEVcqwvBxgFZRWbybk=
+github.com/go-playground/pkg v1.0.1 h1:EsBCgjDTrlaLCflFChT2Q/M4unQQS6DnBDvHTA+fVAI=
+github.com/go-playground/pkg v3.1.4+incompatible h1:trcNe1yKhLdVxwua2EZBS6SHSPjq+DimurUY3mFAWOs=
+github.com/go-playground/pkg v3.1.4+incompatible/go.mod h1:Wg1j+HqWLhhVIfYdaoOuBzdutBEVcqwvBxgFZRWbybk=
 github.com/go-playground/pure v0.0.0-20170911042516-dd99f50b7780 h1:kzaiRTGY77jL8Pqvz3igYWdPPJBQmg7Iky6ytb3lYsc=
 github.com/go-playground/pure v0.0.0-20170911042516-dd99f50b7780/go.mod h1:k2eRJXw80qTBI0vn3rVf3CcZRLtdbPb0FPV7sDZGk5o=
+github.com/go-playground/pure v0.0.0-20190513234712-ab95fef1be7a h1:XORSaodaHB435EPTVxDH/pMbhib/OOSSGaN40XNejc4=
+github.com/go-playground/pure v0.0.0-20190513234712-ab95fef1be7a/go.mod h1:nTRC3AHigULLGsWAUFOVWQsXvK+1G+zyb6MfAmi3Fmw=
+github.com/go-playground/pure v5.0.2+incompatible h1:8wkoQ+s3lpJ5oaYdR6YtnRNF3e9TKNKTlwfMyHD8z2U=
+github.com/go-playground/pure v5.0.2+incompatible/go.mod h1:nTRC3AHigULLGsWAUFOVWQsXvK+1G+zyb6MfAmi3Fmw=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/heetch/confita v0.5.1 h1:EiE32j+Ze0sI0YBeJDSdqTZ32uKz2XCTQIzSgwgfnvk=
@@ -30,3 +39,4 @@ github.com/satori/go.uuid v0.0.0-20180103174451-36e9d2ebbde5 h1:tfcGHuraNSEY9xRb
 github.com/satori/go.uuid v0.0.0-20180103174451-36e9d2ebbde5/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sevlyar/go-daemon v0.1.4 h1:Ayxp/9SNHwPBjV+kKbnHl2ch6rhxTu08jfkGkoxgULQ=
 github.com/sevlyar/go-daemon v0.1.4/go.mod h1:6dJpPatBT9eUwM5VCw9Bt6CdX9Tk6UWvhW3MebLDRKE=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/routing.go
+++ b/routing.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	httpext "github.com/go-playground/pkg/net/http"
 	"github.com/go-playground/pure"
 )
 
@@ -78,7 +79,7 @@ func ChangePassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	np := NewPassword{}
-	if err := pure.Decode(r, true, 104857600, &np); err != nil {
+	if err := pure.Decode(r, httpext.QueryParams, 104857600, &np); err != nil {
 		showError(w, err, http.StatusUnprocessableEntity)
 		return
 	}
@@ -114,7 +115,7 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p := Params{}
-	if err := pure.Decode(r, true, 104857600, &p); err != nil {
+	if err := pure.Decode(r, httpext.QueryParams, 104857600, &p); err != nil {
 		showError(w, err, http.StatusUnprocessableEntity)
 		return
 	}
@@ -130,7 +131,7 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 //Registration - is the registration handler
 func Registration(w http.ResponseWriter, r *http.Request) {
 	var user = NewUser()
-	if err := pure.Decode(r, true, 104857600, &user); err != nil {
+	if err := pure.Decode(r, httpext.QueryParams, 104857600, &user); err != nil {
 		showError(w, err, http.StatusUnprocessableEntity)
 		return
 	}
@@ -146,7 +147,7 @@ func Registration(w http.ResponseWriter, r *http.Request) {
 //Login - is the login handler
 func Login(w http.ResponseWriter, r *http.Request) {
 	var user = NewUser()
-	if err := pure.Decode(r, true, 104857600, &user); err != nil {
+	if err := pure.Decode(r, httpext.QueryParams, 104857600, &user); err != nil {
 		showError(w, err, http.StatusUnprocessableEntity)
 		return
 	}
@@ -186,7 +187,7 @@ func SyncItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var request SyncRequest
-	if err := pure.Decode(r, true, 104857600, &request); err != nil {
+	if err := pure.Decode(r, httpext.QueryParams, 104857600, &request); err != nil {
 		showError(w, err, http.StatusUnprocessableEntity)
 		return
 	}


### PR DESCRIPTION
Hi @tectiv3 

`go-playground/pkg` and `go-playground/pure` are now updated to tagged versions.   Unit suite was tested and I did a functional test. 

Does this cover the compatibility changes?  If there are known Issues i can add them to this PR. 

