### PR TITLE
Increase pw_cost default to be fully compliant with sf0.0.3

### DIFF
--- a/user.go
+++ b/user.go
@@ -69,7 +69,7 @@ func init() {
 //NewUser - user constructor
 func NewUser() User {
 	user := User{}
-	user.PwCost = 5000
+	user.PwCost = 100000
 	user.PwAlg = "sha512"
 	user.PwKeySize = 512
 	user.PwFunc = "pbkdf2"


### PR DESCRIPTION
Hi

SF protocol says the the minimum pw_cost must be 100000:
"Client verifies cost >= minimum cost (100,000 for 003.)"

I was using Curl to debug a Docker container and created an user directly trough the api (without using Standard Notes). I wasn't able to login with that user since the default pw_cost was 5000. Once I did the same request putting pw_cost=100000 it worked

Since the server is compatible woth SF 0.0.3, shouldn't 1000 be the default?